### PR TITLE
Add PIDs for Banana Pi dev boards

### DIFF
--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -230,3 +230,9 @@ PID    | Product name
 0x80DE | Banana Pi Leaf-S3 - UF2 Bootloader
 0x80DF | Banana Pi Leaf-S3 - Arduino
 0x80E0 | Banana Pi Leaf-S3 - CircuitPython
+0x80E1 | Banana Pi Leaf-S2 - UF2 Bootloader
+0x80E2 | Banana Pi Leaf-S2 - Arduino
+0x80E3 | Banana Pi Leaf-S2 - CircuitPython
+0x80E4 | Banana Pi BPI:Bit v2 - UF2 Bootloader
+0x80E5 | Banana Pi BPI:Bit v2 - Arduino
+0x80E6 | Banana Pi BPI:Bit v2 - CircuitPython

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -227,3 +227,6 @@ PID    | Product name
 0x80DB | CircuitArt FeatherS3 - Arduino
 0x80DC | CircuitArt FeatherS3 - UF2 Bootloader
 0x80DD | CircuitArt FeatherS3 - CircuitPython
+0x80DE | Banana Pi Leaf-S3 - UF2 Bootloader
+0x80DF | Banana Pi Leaf-S3 - Arduino
+0x80E0 | Banana Pi Leaf-S3 - CircuitPython

--- a/allocated-pids.txt
+++ b/allocated-pids.txt
@@ -227,12 +227,12 @@ PID    | Product name
 0x80DB | CircuitArt FeatherS3 - Arduino
 0x80DC | CircuitArt FeatherS3 - UF2 Bootloader
 0x80DD | CircuitArt FeatherS3 - CircuitPython
-0x80DE | Banana Pi Leaf-S3 - UF2 Bootloader
-0x80DF | Banana Pi Leaf-S3 - Arduino
-0x80E0 | Banana Pi Leaf-S3 - CircuitPython
-0x80E1 | Banana Pi Leaf-S2 - UF2 Bootloader
-0x80E2 | Banana Pi Leaf-S2 - Arduino
-0x80E3 | Banana Pi Leaf-S2 - CircuitPython
+0x80DE | Banana Pi BPI-Leaf-S3 - UF2 Bootloader
+0x80DF | Banana Pi BPI-Leaf-S3 - Arduino
+0x80E0 | Banana Pi BPI-Leaf-S3 - CircuitPython
+0x80E1 | Banana Pi BPI-Leaf-S2 - UF2 Bootloader
+0x80E2 | Banana Pi BPI-Leaf-S2 - Arduino
+0x80E3 | Banana Pi BPI-Leaf-S2 - CircuitPython
 0x80E4 | Banana Pi BPI:Bit v2 - UF2 Bootloader
 0x80E5 | Banana Pi BPI:Bit v2 - Arduino
 0x80E6 | Banana Pi BPI:Bit v2 - CircuitPython


### PR DESCRIPTION
Hello, I would like to request 9 PIDs for our Banana Pi dev boards.

1. Banana Pi Leaf-S3 dev board with ESP32-S3 chip.
2. Banana Pi Leaf-S2 dev board with ESP32-S2 chip.
3. Banana Pi BPI:Bit v2 dev board with ESP32-S2 chip.

A PID of UF2 Bootloader, Arduino, and CircuitPython for each of these boards, 9 PIDs in total.
———————————————————
Custom PIDs are required due to:

UF2 / UF2-Bootloader - requires a unique PID for the USB device when it boots as a mass storage device as TinyUF2 doesn't allow sharing the same PIDs here.

Arduino - a unique PID allows the board to be listed by the proper board name instead of "generic ESP32 dev board"

CircuitPython - Adafruit requires every board that runs CircuitPython to have a unique PID.
———————————————————
I'm requesting these PIDs on behalf of my company, Banana Pi.

Official website: https://banana-pi.org/

Many thanks for your time.
